### PR TITLE
Generate docs for cores

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -26,6 +26,10 @@ For example for `sd-master`:
 - https://sd-master.test.superdesk.org/mail/ emails
 - https://sd-master.test.superdesk.org/logs/ logs
 
+### Docs
+Docs are generated for `superdek-core` (`<domain>/docs/`), for example:
+- https://sds-master.test.superdesk.org/docs/
+
 # Github integration
 
 After webhook is invoked by Github, `fireq` uses [Github API][gh-statuses] to post statuses.
@@ -144,6 +148,7 @@ Secret: <"secret" from config.json>
 
 ### Login via Github
 Fill `github_id` and `github_secret` config values from [one of applications.][gh-apps]
+
 [gh-apps]: https://github.com/organizations/superdesk/settings/applications
 
 ## Upgrade

--- a/fireq/cli.py
+++ b/fireq/cli.py
@@ -36,7 +36,7 @@ scopes = [
 scopes = namedtuple('Scopes', [i[0] for i in scopes])(*[i for i in scopes])
 checks = {
     scopes.sd.name: ('npmtest', 'flake8'),
-    scopes.sds.name: ('flake8', 'nose', 'behave'),
+    scopes.sds.name: ('flake8', 'nose', 'behave', 'docs'),
     scopes.sdc.name: ('npmtest', 'e2e--part1', 'e2e--part2'),
 }
 

--- a/tpl/superdesk-client/check-docs.sh
+++ b/tpl/superdesk-client/check-docs.sh
@@ -1,0 +1,3 @@
+# TODO: these docs are not working anymore, so it's not used for now
+cd {{repo_client}}
+[ -z "$(grep no-serve tasks/options/dgeni-alive.js)" ] || grunt docs --no-serve

--- a/tpl/superdesk-server/check-docs.sh
+++ b/tpl/superdesk-server/check-docs.sh
@@ -1,0 +1,3 @@
+cd {{repo_server}}/docs
+make html
+[ ! -d {{repo_client}}/dist-deploy ] || cp -Tr _build/html {{repo_client}}/dist-deploy/docs

--- a/tpl/superdesk-server/deploy.sh
+++ b/tpl/superdesk-server/deploy.sh
@@ -1,0 +1,6 @@
+{{>superdesk/deploy.sh}}
+
+# generate docs
+cat <<"EOF" | sh || true
+{{>check-docs.sh}}
+EOF


### PR DESCRIPTION
Docs for [superdesk-client-core](https://github.com/superdesk/superdesk-client-core/) are not working properly now.
So enable docs only for [superdesk-core](https://github.com/superdesk/superdesk-core) in CI.

Ref: #9