### PR TITLE
WIP for #10: Use settings.py and config.js

### DIFF
--- a/fireq/cli.py
+++ b/fireq/cli.py
@@ -142,7 +142,8 @@ def endpoint(tpl, scope=None, *, tpldir=None, expand=None, header=True):
         testing = val('testing') and 1 or ''
         host = val('host', 'localhost')
         host_ssl = val('host_ssl', False) and 1 or ''
-        host_url = 'http%s://%s/' % (host_ssl and 's', host)
+        host_url = 'http%s://%s' % (host_ssl and 's', host)
+        host_ws = 'ws%s://%s' % (host_ssl and 's', host)
         db_host = val('db_host', 'localhost')
         db_name = name
         db_local = db_host == 'localhost'

--- a/tpl/add-settings.py
+++ b/tpl/add-settings.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014, 2015 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import os
+from pathlib import Path
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+
+def env(variable, fallback_value=None):
+    env_value = os.environ.get(variable, '')
+    if len(env_value) == 0:
+        return fallback_value
+    else:
+        if env_value == "__EMPTY__":
+            return ''
+        else:
+            return env_value
+
+
+ABS_PATH = str(Path(__file__).resolve().parent)
+
+init_data = Path(ABS_PATH) / 'data'
+if init_data.exists():
+    INIT_DATA_PATH = init_data
+
+RENDITIONS = {
+    'picture': {
+        'thumbnail': {'width': 220, 'height': 120},
+        'viewImage': {'width': 640, 'height': 640},
+        'baseImage': {'width': 1400, 'height': 1400},
+    },
+    'avatar': {
+        'thumbnail': {'width': 60, 'height': 60},
+        'viewImage': {'width': 200, 'height': 200},
+    }
+}
+
+WS_HOST = env('WSHOST', '0.0.0.0')
+WS_PORT = env('WSPORT', '5100')
+
+LOG_CONFIG_FILE = env('LOG_CONFIG_FILE', 'logging_config.yml')
+SECRET_KEY = env('SECRET_KEY', '')
+NO_TAKES = True
+
+db_host = env('DB_HOST', '{{ db_host }}')
+db_name = env('DB_NAME', '{{ db_name }}')
+
+server_url = urlparse(env('SUPERDESK_URL', '{{ host_url}}/api'))
+URL_PROTOCOL = server_url.scheme or None
+SERVER_NAME = server_url.netloc or None
+SERVER_DOMAIN = server_url.netloc or 'localhost'
+URL_PREFIX = server_url.path.lstrip('/') or ''
+if SERVER_NAME.endswith(':80'):
+    SERVER_NAME = SERVER_NAME[:-3]
+
+CELERYBEAT_SCHEDULE_FILENAME = env('CELERYBEAT_SCHEDULE_FILENAME', '/tmp/celerybeatschedule')
+SUPERDESK_WS_URL = env('SUPERDESK_WS_URL', '{{ host_ws }}/ws')
+CONTENTAPI_URL = env('CONTENTAPI_URL', '{{ host_url }}/contentapi')
+SUPERDESK_CLIENT_URL = env('SUPERDESK_CLIENT_URL', '{{ host_url }}')
+MONGO_URI = env('MONGO_URI', 'mongodb://{}/{}'.format(db_host, db_name))
+CONTENTAPI_MONGO_URI = env('CONTENTAPI_MONGO_URI', 'mongodb://{}/{}_ca'.format(db_host, db_name))
+LEGAL_ARCHIVE_URI = env('LEGAL_ARCHIVE_URI', 'mongodb://{}/{}_la'.format(db_host, db_name))
+ARCHIVED_URI = env('ARCHIVED_URI', 'mongodb://{}/{}_ar'.format(db_host, db_name))
+ELASTICSEARCH_URL = env('ELASTICSEARCH_URL', 'http://{}:9200'.format(db_host))
+ELASTICSEARCH_INDEX = env('ELASTICSEARCH_INDEX', db_name)
+CONTENTAPI_ELASTICSEARCH_INDEX = env('CONTENTAPI_ELASTICSEARCH_INDEX', '{}_ca'.format(db_name))
+REDIS_URL = env('REDIS_URL', 'redis://{}:6379/1'.format(db_host))
+CELERY_BROKER_URL = env('CELERY_BROKER_URL', REDIS_URL)
+BROKER_URL = env('CELERY_BROKER_URL', REDIS_URL)
+AMAZON_ACCESS_KEY_ID = env('AMAZON_ACCESS_KEY_ID', '')
+AMAZON_SECRET_ACCESS_KEY = env('AMAZON_SECRET_ACCESS_KEY', '')
+AMAZON_CONTAINER_NAME = env('AMAZON_CONTAINER_NAME', '')
+AMAZON_REGION = env('AMAZON_REGION', 'eu-west-1')
+AMAZON_S3_SUBFOLDER = env('AMAZON_S3_SUBFOLDER', '')
+AMAZON_SERVE_DIRECT_LINKS = env('AMAZON_SERVE_DIRECT_LINKS', True)
+AMAZON_S3_USE_HTTPS = env('AMAZON_S3_USE_HTTPS', False)
+AMAZON_SERVER = env('AMAZON_SERVER', 'amazonaws.com')
+AMAZON_PROXY_SERVER = env('AMAZON_PROXY_SERVER', '')
+AMAZON_URL_GENERATOR = env('AMAZON_URL_GENERATOR', 'default')
+MAIL_SERVER = env('MAIL_SERVER', 'localhost')
+MAIL_PORT = env('MAIL_PORT', 25)
+MAIL_USE_TLS = env('MAIL_USE_TLS', False)
+MAIL_USE_SSL = env('MAIL_USE_SSL', False)
+MAIL_USERNAME = env('MAIL_USERNAME', '')
+MAIL_PASSWORD = env('MAIL_PASSWORD', '')
+MAIL_FROM = env('MAIL_FROM', '')
+SENTRY_DSN = env('SENTRY_DSN', '')
+IFRAMELY_KEY = env('IFRAMELY_KEY', '')
+NEW_RELIC_APP_NAME = env('NEW_RELIC_APP_NAME', '')
+NEW_RELIC_LICENSE_KEY = env('NEW_RELIC_LICENSE_KEY', '')

--- a/tpl/ci-deploy.sh
+++ b/tpl/ci-deploy.sh
@@ -2,11 +2,6 @@ lxc=${lxc:-"{{uid}}"}
 db_host="{{db_host}}"
 db_name="{{uid}}"
 
-# env config
-cat <<EOF | {{ssh}} $lxc "cat > {{config}}"
-{{>deploy-config.sh}}
-EOF
-
 # run init
 if [ -f tpl/init/{{uid}}.sh ]; then
     cfg={{uid}}

--- a/tpl/superdesk/add-config.js
+++ b/tpl/superdesk/add-config.js
@@ -1,0 +1,20 @@
+window.superdeskConfig={
+    defaultTimezone: "Europe/Berlin",
+    server: {
+        url: "{{ host_url }}/api",
+        ws: "{{ host_ws }}/ws"
+    },
+    iframely: {
+        key: "${IFRAMELY_KEY:-}"
+    },
+    raven: {
+        dsn: "${RAVEN_DSN:-}"
+    },
+    publisher: {
+        protocol: "https",
+        tenant: "${PUBLISHER_API_DOMAIN:-}",
+        domain: "${PUBLISHER_API_SUBDOMAIN:-}",
+        base: "api/v1"
+    }
+};
+

--- a/tpl/superdesk/build-client.sh
+++ b/tpl/superdesk/build-client.sh
@@ -8,10 +8,4 @@ time npm install
 # TODO: maybe remove "--force" later
 # vars are used in "webpack.config.js"
 time \
-SUPERDESK_URL='<SUPERDESK_URL>' \
-SUPERDESK_WS_URL='<SUPERDESK_WS_URL>' \
-SUPERDESK_RAVEN_DSN='<RAVEN_DSN>' \
-IFRAMELY_KEY='<IFRAMELY_KEY>' \
-PUBLISHER_API_DOMAIN='<PUBLISHER_API_DOMAIN>' \
-PUBLISHER_API_SUBDOMAIN='<PUBLISHER_API_SUBDOMAIN>' \
 grunt build{{#dev}} --force{{/dev}}

--- a/tpl/superdesk/deploy-dist.sh
+++ b/tpl/superdesk/deploy-dist.sh
@@ -3,12 +3,12 @@ dist_orig={{repo_client}}/dist
 dist=${dist_orig}-deploy
 rm -rf $dist
 cp -r $dist_orig $dist
-sed -i \
-    -e "s|<SUPERDESK_URL>|http$SSL://$HOST/api|" \
-    -e "s|<SUPERDESK_WS_URL>|ws$SSL://$HOST/ws|" \
-    -e "s|<IFRAMELY_KEY>|${IFRAMELY_KEY:-}|" \
-    -e "s|<RAVEN_DSN>|${RAVEN_DSN:-}|" \
-    -e "s|<PUBLISHER_API_DOMAIN>|${PUBLISHER_API_DOMAIN:-}|" \
-    -e "s|<PUBLISHER_API_SUBDOMAIN>|${PUBLISHER_API_SUBDOMAIN:-}|" \
-    $dist/app.bundle.*
-unset dist_orig dist
+
+#load env variables needed for config.js
+. $honcho_env
+configjs=$(ls $dist | grep -E "config.\w+.js")
+cat <<EOF > $dist/$configjs
+{{>add-config.js}}
+EOF
+
+unset dist_orig dist configjs

--- a/tpl/superdesk/deploy.sh
+++ b/tpl/superdesk/deploy.sh
@@ -1,33 +1,24 @@
 ### deploy
-# write config if not exist
-config={{config}}
-[ -f $config ] || cat <<EOF > $config
-{{>deploy-config.sh}}
+honcho_env={{repo}}/.env
+cat <<"EOF" >> $honcho_env
+LANG=en_US.UTF-8
+LANGUAGE=en_US:en
+LC_ALL=en_US.UTF-8
+PYTHONIOENCODING="utf-8"
+PYTHONUNBUFFERED=1
+C_FORCE_ROOT="False"
 EOF
 
-# env.sh
-envfile={{repo}}/env.sh
-cat <<"EOF" > $envfile
-{{>deploy-env.sh}}
+sd_settings={{repo_server}}/settings.py
+cat <<EOF > $sd_settings
+{{>add-settings.py}}
 EOF
 
-# load env.sh and config in activation script
-activate={{repo_env}}/bin/activate
-grep "$envfile" $activate || cat <<EOF >> $activate
-set -a
-[ -f $config ] && . $config
-. $envfile
-set +a
-EOF
-unset envfile activate config
 _activate
-
 
 {{>deploy-dist.sh}}
 
-
 {{>add-nginx.sh}}
-
 
 [ -z "${prepopulate-1}" ] || (
 {{>prepopulate.sh}}

--- a/tpl/superdesk/nginx.conf
+++ b/tpl/superdesk/nginx.conf
@@ -9,7 +9,7 @@ location /ws {
 
 location /api {
     proxy_pass http://localhost:5000;
-    proxy_set_header Host $HOST;
+    proxy_set_header Host {{ host }};
     expires epoch;
 
     sub_filter_once off;
@@ -20,7 +20,7 @@ location /api {
 {{#is_superdesk}}
 location /contentapi {
     proxy_pass http://localhost:5400;
-    proxy_set_header Host $HOST;
+    proxy_set_header Host {{ host }};
     expires epoch;
 }
 {{/is_superdesk}}


### PR DESCRIPTION
This is a WIP. It's not finished. It's mainly an idea of how to use
settings.py and honcho .env file for app settings.

It's working in standalone mode, i.e, for users. CI hasn't been
completed. However, user initialization needs to be fixed. 
Aside from that, I can login into superdesk app.

When CI customization is needed, env variables should be written to
{{repo}}/.env from tpl/init/sd-x.sh. Settings.py should do the rest.

config.js still needs to be improved/thought.