### PR TITLE
Adding ssh proxy using "config.proxy_ssh"

### DIFF
--- a/fireq/__init__.py
+++ b/fireq/__init__.py
@@ -31,6 +31,7 @@ def get_conf():
         ('url_prefix', ''),
         ('status_prefix', 'fire:'),
         ('protected_dbs', []),
+        ('proxy_ssh', {}),
 
         ('github_id', None),
         ('github_secret', None),

--- a/fireq/cli.py
+++ b/fireq/cli.py
@@ -452,11 +452,18 @@ def ci_nginx(lxc_prefix=None, ssl=False, live=False):
         'host': '%s.%s' % (n, conf['domain']),
         'ssl': not n.split('-', 1)[0].endswith('pr') and ssl,
     } for n in names]
+    proxy_ssh = [{
+        'port': p,
+        'name': n,
+        'host': '%s.%s' % (n, conf['domain'])
+    } for p, n in conf['proxy_ssh'].items()]
     txt = render_tpl('{{>ci-nginx.sh}}', {
         'label': label,
         'hosts': hosts,
         'cert': ssl,
         'live': live and 1 or '',
+        'proxy_ssh': proxy_ssh,
+        'ssh': 'ssh %s' % ssh_opts,
     })
     sh(txt, quiet=True)
 

--- a/tpl/ci-nginx.sh
+++ b/tpl/ci-nginx.sh
@@ -62,4 +62,28 @@ server {
 }
 {{/hosts}}
 EOF
+# proxy ssh ports
+cat <<"EOF" > /etc/nginx/sites-ssh-enabled/{{label}}
+{{#proxy_ssh}}
+server {
+    listen {{port}};
+    proxy_pass {{name}}:22;
+}
+{{/proxy_ssh}}
+EOF
+{{#proxy_ssh}}
+cat <<"EOF2" | {{ssh}} {{name}}
+cat <<"EOF" >> /root/.ssh/authorized_keys
+{{>init/.authorized_keys}}
+EOF
+
+cat <<"EOF" > /etc/nginx/conf.d/ssh.inc
+location /ssh {
+    add_header Content-Type text/plain;
+    return 200 '{{ssh}} root@{{host}} -p {{port}}';
+}
+EOF
+nginx -s reload
+EOF2
+{{/proxy_ssh}}
 nginx -s reload


### PR DESCRIPTION
Usage `./fire ci-nginx` with settings like this:
```
"proxy_ssh": {
    "2200": "sd-master",
    "2201": "sd-naspeh"
}
```
Link `<domain>/ssh` shows `ssh` command with proper port.

@scanterog you can check this: https://sd-thesource.test.superdesk.org/ssh