### PR TITLE
Allow overwriting of some files with private repository

### DIFF
--- a/fireq/__init__.py
+++ b/fireq/__init__.py
@@ -38,6 +38,7 @@ def get_conf():
         ('github_basic', None),
         ('github_orgs', ['superdesk']),
         ('github_callback', '/oauth_callback/github'),
+        ('uri_priv_repo', ''),
 
         ('log_url', lambda c: 'http://%s/logs/' % c['domain']),
         ('log_root', lambda c: '%s/logs' % c['tmp_root']),

--- a/fireq/cli.py
+++ b/fireq/cli.py
@@ -25,15 +25,17 @@ from . import log, conf, pretty_json, gh, lock
 dry_run = False
 ssh_opts = '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 
-Scope = namedtuple('Scope', 'name, tpldir, repo')
+fil_priv_repo = conf['uri_priv_repo'] + 'sdp/superdesk-fidelity'
+
+Scope = namedtuple('Scope', 'name, tpldir, repo, priv_repo')
 scopes = [
-    Scope('sd', 'superdesk', 'superdesk/superdesk'),
-    Scope('sds', 'superdesk-server', 'superdesk/superdesk-core'),
-    Scope('sdc', 'superdesk-client', 'superdesk/superdesk-client-core'),
-    Scope('sdp', 'superdesk-planning', 'superdesk/superdesk-planning'),
-    Scope('ntb', 'superdesk', 'superdesk/superdesk-ntb'),
-    Scope('fil', 'superdesk', 'superdesk/superdesk-fidelity'),
-    Scope('lb', 'liveblog', 'liveblog/liveblog'),
+    Scope('sd', 'superdesk', 'superdesk/superdesk', ''),
+    Scope('sds', 'superdesk-server', 'superdesk/superdesk-core', ''),
+    Scope('sdc', 'superdesk-client', 'superdesk/superdesk-client-core', ''),
+    Scope('sdp', 'superdesk-planning', 'superdesk/superdesk-planning', ''),
+    Scope('ntb', 'superdesk', 'superdesk/superdesk-ntb', ''),
+    Scope('fil', 'superdesk', 'superdesk/superdesk-fidelity', fil_priv_repo),
+    Scope('lb', 'liveblog', 'liveblog/liveblog', ''),
 ]
 scopes = namedtuple('Scopes', [i[0] for i in scopes])(*[i for i in scopes])
 checks = {
@@ -138,6 +140,7 @@ def endpoint(tpl, scope=None, *, tpldir=None, expand=None, header=True):
         repo_remote = val('repo_remote') or (
             'https://github.com/superdesk/superdesk.git'
         )
+        priv_repo_remote = val('priv_repo_remote') or ''
         repo_server = val('repo_server', '%s/server' % repo)
         repo_client = val('repo_client', '%s/client' % repo)
 
@@ -171,9 +174,14 @@ def endpoint(tpl, scope=None, *, tpldir=None, expand=None, header=True):
         search_dirs.insert(0, tpldir)
 
     # TODO: move superdesk based logic to separate file
+    priv_repo_remote = ''
+    if scope.priv_repo:
+        priv_repo_remote = scope.priv_repo + '.git'
+
     expand.update({
         'scope': scope.name,
-        'repo_remote': 'https://github.com/%s.git' % scope.repo
+        'repo_remote': 'https://github.com/%s.git' % scope.repo,
+        'priv_repo_remote': priv_repo_remote
     })
     if scope == scopes.sd:
         pass

--- a/tpl/ci-build.sh
+++ b/tpl/ci-build.sh
@@ -14,6 +14,9 @@ lxc-destroy -fn $lxc || true
 
 # create new container and build code
 lxc-copy -s -n {{lxc_base}} -N $lxc
+{{#priv_repo_remote}}
+cp /root/.ssh/* /var/lib/lxc/$lxc/rootfs/root/.ssh/
+{{/priv_repo_remote}}
 ./fire lxc-wait --start $lxc
 cat <<"EOF2" | {{ssh}} $lxc
 {{>header.sh}}

--- a/tpl/superdesk/build-src-repo.sh
+++ b/tpl/superdesk/build-src-repo.sh
@@ -17,5 +17,13 @@ if [ ! -d $repo/.git ]; then
     git checkout ${repo_sha:-FETCH_HEAD}
     unset repo_sha
     {{/is_pr}}
-    unset repo repo_ref
+    unset repo_ref
+
+    {{#priv_repo_remote}}
+    # for now use just master by default
+    GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
+    git -C /tmp/ clone {{priv_repo_remote}} sd_custom
+    cp -R /tmp/sd_custom/* $repo/
+    {{/priv_repo_remote}}
+    unset repo
 fi


### PR DESCRIPTION
This allows to overwrite files that must be kept private in a private repository like our stash repo. The idea is to put **only the files** that needs to be added or replaced in our stash repo but with the same folder structure as in the GitHub repo. Hence, no need to replicate all files.

The private repository URI must be configured at the config.json file with the key uri_priv_repo.

Actually, the fireq service in host7 is running now in this branch and fidelity repo have been built succesfully but it would be good if someone else can take a look in case I've missed something. Once merged, server branch must be changed to master again.