### PR TITLE
Replace chromium by chrome for e2e tests

### DIFF
--- a/tpl/add-chrome.sh
+++ b/tpl/add-chrome.sh
@@ -1,8 +1,10 @@
-# chromium instead of chrome :)
-if ! _skip_install chromium-browser; then
-    apt-get install -y --no-install-recommends xvfb chromium-browser
+# chrome instead of chromium.
+# chromium 59.0.3071.109 fails at creating session.
+if ! _skip_install google-chrome-stable; then
+    curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+    echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+    apt-get update
+    apt-get install -y --no-install-recommends xvfb google-chrome-stable
 fi
 
-# inspired by http://stackoverflow.com/questions/12258086
-sed -i -e 's/CHROMIUM_FLAGS/CHROMIUM_FLAGS="--no-sandbox"/' /etc/chromium-browser/default
-export CHROME_BIN=$(which chromium-browser) && $CHROME_BIN --version
+export CHROME_BIN=$(which google-chrome-stable) && $CHROME_BIN --version


### PR DESCRIPTION
e2e tests are working with latest google chrome (60.0.3112.78-1) but it's not working with latest chromium (59.0.3071.109) available in ubuntu 16 repo. It was working before because it was using chromium 58.0.3029.110. In new chromium it fails to create session: `From: Task: WebDriver.createSession()`

Aside from that, in order to make npmtest work, it also needs changes in karma.conf: https://github.com/superdesk/superdesk-client-core/pull/1749. I've tested it and it's working. You can check results here: https://test.superdesk.org/logs/3/dev2/latest/sdc-fixtest/. Alternatively, we might look another way to provide the `--no-sandbox` as default custom param to chrome (it doesn't provide a file as chromium does).