### PR TITLE
fix superdesk-analytics build

### DIFF
--- a/tpl/superdesk-analytics/build-src.sh
+++ b/tpl/superdesk-analytics/build-src.sh
@@ -2,7 +2,7 @@
 
 cd {{repo}}
 sed -i 's/.*superdesk-analytics.git.*/-e ..\/analytics/' server/requirements.txt
-sed -i -re 's/("superdesk-analytics":)[^.]*(,?)/\1 "file:..\/analytics"\2/' client/package.json
+sed -i -re 's/("superdesk-analytics":)[^,]*(,?)/\1 "file:..\/analytics"\2/' client/package.json
 cat server/requirements.txt
 cat client/package.json
 


### PR DESCRIPTION
it was removing trailing `,` from package.json which broke npm install