### PR TITLE
fix node memory setting

### DIFF
--- a/tpl/superdesk-client/build.sh
+++ b/tpl/superdesk-client/build.sh
@@ -26,4 +26,4 @@ time pip install -Ur requirements.txt
 cd {{repo_client}}
 time npm install --unsafe-perm
 # will be used for e2e tests
-time grunt build --webpack-no-progress
+time node --max-old-space-size=4096  `which grunt` build --webpack-no-progress

--- a/tpl/superdesk/deploy.sh
+++ b/tpl/superdesk/deploy.sh
@@ -16,8 +16,7 @@ _activate
 {{^develop}}
 [ -z "${grunt_build-1}" ] || (
 cd {{repo_client}}
-export NODE_OPTIONS=--max_old_space_size=4096
-time grunt build --webpack-no-progress
+time node --max-old-space-size=4096  `which grunt` build --webpack-no-progress
 )
 {{/develop}}
 
@@ -67,7 +66,7 @@ EOF
 cat <<"EOF" > {{repo}}/watch-client
 . {{activate}}
 cd {{repo_client}}
-grunt build --webpack-devtool=cheap-eval-source-map --webpack-no-progress
+time node --max-old-space-size=4096  `which grunt` build --webpack-no-progress
 
 [ -d {{repo}}/client-core ] && cd {{repo}}/client-core
 while inotifywait -e modify -e create -e delete -r .; do


### PR DESCRIPTION
Fixes webpack build crashing due to getting out of memory:

```
Running "webpack:build" (webpack) task
 92% chunk asset optimization                                                             
<--- Last few GCs --->
[21719:0x2655d30]   194174 ms: Mark-sweep 1384.7 (1497.6) -> 1384.6 (1499.6) MB, 1306.0 / 0.0 ms  allocation failure GC in old space requested
[21719:0x2655d30]   195322 ms: Mark-sweep 1384.6 (1499.6) -> 1384.5 (1460.6) MB, 1147.4 / 0.0 ms  last resort GC in old space requested
[21719:0x2655d30]   196633 ms: Mark-sweep 1384.5 (1460.6) -> 1384.5 (1455.6) MB, 1309.6 / 0.0 ms  last resort GC in old space requested
<--- JS stacktrace --->
==== JS stack trace =========================================
Security context: 0x152283425879 <JSObject>
    1: /* anonymous */ [/home/tomas/DevTools/superdesk-repos/superdesk/client/node_modules/webpack-sources/node_modules/source-map/lib/source-node.js:~174] [pc=0x3016d34e3b12](this=0x3ffc36f268c1 <SourceNode map = 0x224525fce31>,chunk=0x61f7486fca9 <SourceNode map = 0x224525fce31>)
    2: arguments adaptor frame: 3->1
    3: forEach(this=0x3ffc36f26911 <JSArray[1082859]>)
    4: SourceNode_add [...
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [grunt]
 2: 0x8c21ec [grunt]
 3: v8::Utils::ReportOOMFailure(char const*, bool) [grunt]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [grunt]
 5: v8::internal::Factory::NewUninitializedFixedArray(int) [grunt]
 6: 0xd4b133 [grunt]
 7: v8::internal::Runtime_GrowArrayElements(int, v8::internal::Object**, v8::internal::Isolate*) [grunt]
 8: 0x3016d32042fd
Aborted (core dumped)
```