### PR TITLE
Use new version of GitHub App installation access token endpoint

### DIFF
--- a/fireq/gh.py
+++ b/fireq/gh.py
@@ -36,7 +36,7 @@ def auth(url=None):
     org = 'superdesk'
     if url and 'liveblog' in url:
         org = 'liveblog'
-    auth_url = 'https://api.github.com/installations/%s/access_tokens' % \
+    auth_url = 'https://api.github.com/app/installations/%s/access_tokens' % \
         conf['github_installations'][org]
     headers = auth_jwt()
     headers['Accept'] = 'application/vnd.github.machine-man-preview+json'


### PR DESCRIPTION
👋 from GitHub.

The `/installations/:installation_id/access_tokens` GitHub API endpoint is no longer documented and will soon be deprecated. As the Fireq App uses this endpoint extensively (~40,000 calls per day), we hope you'll accept this PR to keep your App working as intended.

This branch updates the endpoint to the preferred and supported version: [`app/installations/:installation_id/access_tokens`](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation). The response from the new endpoint is the same as the old endpoint, so there should be no other functional changes necessary.