### PR TITLE
Build SAMS after installing superdesk-core

### DIFF
--- a/tpl/superdesk/build.sh
+++ b/tpl/superdesk/build.sh
@@ -3,11 +3,11 @@
 
 {{>build-src.sh}}
 
-{{>build-sams.sh}}
-
 cd {{repo_server}}
 [ -f dev-requirements.txt ] && req=dev-requirements.txt || req=requirements.txt
 time pip install -Ur $req
+
+{{>build-sams.sh}}
 
 cd {{repo_client}}
 time npm install --unsafe-perm


### PR DESCRIPTION
This is because `build-sams` requires the `.fireq.json` file from `superdesk-core` after installing it