### PR TITLE
SMTPServer and process_message sig update for 3.6

### DIFF
--- a/tpl/add-smtp.py
+++ b/tpl/add-smtp.py
@@ -24,7 +24,7 @@ class Server(smtpd.SMTPServer, object):
         path.mkdir(exist_ok=True)
         self._path = path
 
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, **kwargs):
         msg = Parser().parsestr(data)
         subject = msg['subject']
         log.info('to=%r subject=%r', rcpttos, subject)
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     log.info('Starting SMTP server at {0}:{1}'.format(args.addr, args.port))
-    server = Server(args.path, (args.addr, args.port), None)
+    server = Server(args.path, (args.addr, args.port), None, decode_data=True)
     try:
         asyncore.loop()
     except KeyboardInterrupt:


### PR DESCRIPTION
Ubuntu 16.04 has updated its latest stable Python 3.6 and that now has changed how its `smtpd` behaves. It now defaults the `decode_data` to `False` and requires you to provide a dictionary for in `process_message` to process more `mail_options`.

Ergo, this commit!

Ref: https://python.readthedocs.io/en/stable/whatsnew/3.5.html#smtpd