### PR TITLE
run schema:migrate when test_data=0

### DIFF
--- a/tpl/superdesk/prepopulate.sh
+++ b/tpl/superdesk/prepopulate.sh
@@ -33,6 +33,7 @@ if _missing_db; then
     python manage.py app:prepopulate || :
 else
     python manage.py data:upgrade
+    python manage.py schema:migrate || :
     python manage.py app:initialize_data
 fi
 {{/test_data}}


### PR DESCRIPTION
The `qa-02-00` branch was failing to build with  Superdesk-Core >= 2.0.5 because schema:migrate was not being executed