### PR TITLE
Lock setuptools and pip versions for Liveblog

### DIFF
--- a/tpl/liveblog/build.sh
+++ b/tpl/liveblog/build.sh
@@ -4,6 +4,8 @@
 {{>superdesk/build-src.sh}}
 
 cd {{repo_server}}
+time pip install 'pip<=20.2.3'
+time pip install 'setuptools<50'
 [ -f dev-requirements.txt ] && req=dev-requirements.txt || req=requirements.txt
 time pip install -U -r $req
 


### PR DESCRIPTION
Liveblog test instances deployments are failing and I think it's because `pip` has changed the way it resolves dependency conflicts. Given that we haven't upgraded Liveblog to use a newer version of `superdesk` and other dependencies, we need to stick to these versions for now.