### PR TITLE
update test server dir

### DIFF
--- a/tpl/superdesk-client/build.sh
+++ b/tpl/superdesk-client/build.sh
@@ -28,13 +28,26 @@ unset chunks
 cd {{repo}}/server
 time pip install -r requirements.txt
 
-# use superdesk-core from here
-cd {{repo_client}}/test-server
-time pip install -Ur requirements.txt
+if [ -d {{repo}}/e2e/server ]; then # handles new test server location: /client/e2e/server
+    # use superdesk-core from here
+    cd {{repo_client}}/e2e/server
+    time pip install -Ur requirements.txt
 
-{{>superdesk/build-sams.sh}}
+    {{>superdesk/build-sams.sh}}
 
-cd {{repo_client}}
-time npm ci --unsafe-perm || time npm install --unsafe-perm --no-audit
-# will be used for e2e tests
-time node --max-old-space-size=4096  `which grunt` build --webpack-no-progress
+    cd {{repo_client}}/e2e/client
+    time npm ci --unsafe-perm || time npm install --unsafe-perm --no-audit
+    # will be used for e2e tests
+    time npm run build
+else # handles old test server location: /client/test-server (keeping to avoid existing releases from breaking)
+    # use superdesk-core from here
+    cd {{repo_client}}/test-server
+    time pip install -Ur requirements.txt
+
+    {{>superdesk/build-sams.sh}}
+
+    cd {{repo_client}}
+    time npm ci --unsafe-perm || time npm install --unsafe-perm --no-audit
+    # will be used for e2e tests
+    time node --max-old-space-size=4096  `which grunt` build --webpack-no-progress
+fi

--- a/tpl/superdesk-client/build.sh
+++ b/tpl/superdesk-client/build.sh
@@ -28,7 +28,7 @@ unset chunks
 cd {{repo}}/server
 time pip install -r requirements.txt
 
-if [ -d {{repo}}/e2e/server ]; then # handles new test server location: /client/e2e/server
+if [ -d {{repo_client}}/e2e/server ]; then # handles new test server location: /client/e2e/server
     # use superdesk-core from here
     cd {{repo_client}}/e2e/server
     time pip install -Ur requirements.txt


### PR DESCRIPTION
I have changed test server directory from `test-server` to `e2e/server` and fireq is failing on that [PR](https://github.com/superdesk/superdesk-client-core/pull/3983) with the following message:
```
-bash: line 262: cd: /opt/superdesk/client-core/test-server: No such file or directory
```

I also need to change the build, so it runs `npm run build` and allows the client to handle the details. I have added a branch for new behavior, and kept the `else` for old so it works for existing releases.