### PR TITLE
Revert "fix(install): Use pip v21.2"

### DIFF
--- a/tpl/superdesk/build-init.sh
+++ b/tpl/superdesk/build-init.sh
@@ -54,4 +54,4 @@ EOF
 {{/develop}}
 
 _activate
-pip install -U 'pip<21.3' wheel setuptools
+pip install -U pip wheel setuptools


### PR DESCRIPTION
This reverts commit 90255cfd968aadc3ed44fb86ef5a8732838249a7.

Pip has now fixed this issue. This version restriction is causing issues with NewsHub build (https://github.com/superdesk/newsroom-app-stt/pull/1)