### PR TITLE
Fix unreachable elastic port mapping issue

### DIFF
--- a/tpl/liveblog/prepopulate.sh
+++ b/tpl/liveblog/prepopulate.sh
@@ -1,5 +1,8 @@
 ### prepopulate
 _activate
+
+unset ELASTIC_PORT
+unset _ELASTIC_PORT
 cd {{repo}}/server
 if _missing_db; then
     [ -f app_init_elastic.py ] && python app_init_elastic.py


### PR DESCRIPTION
These (two) vars are already coming from Liveblog .env file during activation; thus causing a confliction, and were overwritten by default Superdesk templates. Since Liveblog has its own backend which communicates over to 9200 so unsetting the prior ( inherited) vars, resolves this issue.

P.S. unfortunately, this bug was monkey patched (directly on the server) as of now; until then this https://github.com/superdesk/fireq/commit/08bd95562c14cd7acad5ce396cb3bb6b5fef2ff1 PR gets merged ; that reverted the patch and messed up Liveblog CI deployments.