### PR TITLE
[SDESK-7672] Skip building instances for PRs by bots

### DIFF
--- a/fireq/web.py
+++ b/fireq/web.py
@@ -195,6 +195,14 @@ def get_hook_ctx(headers, body, **extend):
         if body['action'] not in ('opened', 'reopened', 'synchronize'):
             log.info('skip %s:%s', event, body['action'])
             return
+
+        try:
+            if body['pull_request']['user']['type'].lower() == 'bot':
+                log.info('skip %s:%s - created by a bot', event, body['action'])
+                return
+        except (KeyError, TypeError, AttributeError):
+            pass
+
         ref = 'pull/%s' % body['number']
         sha = body['pull_request']['head']['sha']
     elif event == 'push':


### PR DESCRIPTION
### Purpose
Instances on our infrastructure are created for PRs by dependabot. These instances aren't used by our team to verify features etc.

### What has changed
Skip building instances for PRs created by a `Bot` user type.

**Note:** If needing to verify building instances from dependabot PRs, we should use Github actions instead

Docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request

Partial example webhook body:
```json
{
    "pull_request": {
        "url": "https://api.github.com/repos/superdesk/superdesk/pulls/3734",
        "title": "Bump superdesk-core from `17efc4f` to `6ac2650` in /client",
        "user": {
            "login": "dependabot[bot]",
            "id": 49699333,            
            "type": "Bot"
        }
    }
}
```