### PR TITLE
[SDESK-7591] Install highcharts server if analytics is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ cat files/superdesk/install | ./fire lxc-ssh sd
 ```
 
 ## History
-Details in according issue: [SDESK-146](https://dev.sourcefabric.org/browse/SDESK-146).
+Details in according issue: [SDESK-146](https://sofab.atlassian.net/browse/SDESK-146).

--- a/tpl/superdesk/build.sh
+++ b/tpl/superdesk/build.sh
@@ -24,4 +24,7 @@ cd {{repo_client}}
 
 {{>build-node-version.sh}}
 
+# if analytics is enabled in fireq.json, install highcharts server
+{{>install-highcharts-server.sh}}
+
 time npm ci --unsafe-perm || time npm install --unsafe-perm --no-audit

--- a/tpl/superdesk/build.sh
+++ b/tpl/superdesk/build.sh
@@ -12,6 +12,9 @@ time pip install -Ur requirements.txt
 _merge_json_from_env_file
 _print_json_config
 
+# if analytics is enabled in fireq.json, install highcharts server
+{{>install-highcharts-server.sh}}
+
 {{>build-sams.sh}}
 
 # if grammalecte is enabled in fireq.json, install grammalecte server
@@ -23,8 +26,5 @@ _print_json_config
 cd {{repo_client}}
 
 {{>build-node-version.sh}}
-
-# if analytics is enabled in fireq.json, install highcharts server
-{{>install-highcharts-server.sh}}
 
 time npm ci --unsafe-perm || time npm install --unsafe-perm --no-audit

--- a/tpl/superdesk/install-highcharts-server.sh
+++ b/tpl/superdesk/install-highcharts-server.sh
@@ -1,7 +1,7 @@
 if [ `_get_json_value analytics` == "true" ]; then
     if ! install-highcharts-server; then
         echo "WARNING: Failed to install highcharts-export-server."
-        exit 0
+    else
+        echo "Highcharts export server installed successfully."
     fi
-    echo "Highcharts export server installed successfully."
 fi

--- a/tpl/superdesk/install-highcharts-server.sh
+++ b/tpl/superdesk/install-highcharts-server.sh
@@ -1,7 +1,7 @@
 if [ `_get_json_value analytics` == "true" ]; then
     if ! install-highcharts-server; then
-        echo "WARNING: Failed to install highcharts-server."
+        echo "WARNING: Failed to install highcharts-export-server."
         exit 0
     fi
-    echo "Highcharts server installed successfully."
+    echo "Highcharts export server installed successfully."
 fi

--- a/tpl/superdesk/install-highcharts-server.sh
+++ b/tpl/superdesk/install-highcharts-server.sh
@@ -1,0 +1,7 @@
+if [ `_get_json_value analytics` == "true" ]; then
+    if ! install-highcharts-server; then
+        echo "WARNING: Failed to install highcharts-server."
+        exit 0
+    fi
+    echo "Highcharts server installed successfully."
+fi


### PR DESCRIPTION
### Purpose 
Add support for conditional installation of the Highcharts export server if `analytics` is enabled in `fireq.json`. The highcharts export server is required for the analytics scheduled email reports to work properly. 

### What has changed
- Added a new script `install-highcharts-server.sh` that checks if analytics is enabled via the analytics flag in `.fireq.json` and only proceeds with installation if analytics is set to "true"
- Modified `build.sh` to include the highcharts export server installation step

This PR depends on https://github.com/superdesk/superdesk-analytics/pull/183 so the `install-highcharts-server` command is available.

Related to [SDESK-7591]

[SDESK-7591]: https://sofab.atlassian.net/browse/SDESK-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ